### PR TITLE
Detect non integers as numbers

### DIFF
--- a/src/util/stringUtils.js
+++ b/src/util/stringUtils.js
@@ -7,7 +7,7 @@ class StringUtils {
     }
 
     getValueFormatByType(value) {
-        let isNumber = /^\d+$/.test(value);
+        let isNumber = !isNaN(value);
         if (isNumber) {
             return Number(value);
         }

--- a/src/util/stringUtils.js
+++ b/src/util/stringUtils.js
@@ -14,10 +14,10 @@ class StringUtils {
         return String(value);
     }
 
-    hasContent(values){
-        if(values.length >0){
-            for(let i=0; i<values.length;i++){
-                if(values[i]){
+    hasContent(values) {
+        if (values.length > 0) {
+            for (let i = 0; i < values.length; i++) {
+                if (values[i]) {
                     return true;
                 }
             }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -16,7 +16,7 @@ let expectedJson = [{
     lastName: 'Raison',
     email: 'nraison1@wired.com',
     gender: 'Female',
-    age: "32",
+    age: "32.5",
     birth: '10.05.2000'
 }];
 
@@ -35,13 +35,12 @@ describe('API testing', function () {
             //then
             expect(result.length).to.equal(expectedJson.length);
             expect(result).to.deep.equal(expectedJson);
-
         });
 
         it('should return json array with value formatted by type', function () {
             //given
             expectedJson[0].age = 96;
-            expectedJson[1].age = 32;
+            expectedJson[1].age = 32.5;
 
             //when
             let result = index.formatValueByType().getJsonFromCsv(fileInputName);
@@ -49,7 +48,6 @@ describe('API testing', function () {
             //then
             expect(result.length).to.equal(expectedJson.length);
             expect(result).to.deep.equal(expectedJson);
-
         });
 
         it('should return json array that contains the same property of the csv header', function () {
@@ -65,7 +63,7 @@ describe('API testing', function () {
         });
 
 
-        it('should return json array from csv with tilde ad field delimiter', function () {
+        it('should return json array from csv with tilde as field delimiter', function () {
             //given
 
             //when
@@ -74,7 +72,6 @@ describe('API testing', function () {
             //then
             expect(result.length).to.equal(expectedJson.length);
             expect(result).to.deep.equal(expectedJson);
-
         });
     });
 });

--- a/test/resource/input.csv
+++ b/test/resource/input.csv
@@ -1,3 +1,3 @@
 firstName;lastName;email;gender;age;birth
 Constantin;Langsdon;clangsdon0@hc360.com;Male;96;10.02.1965
-Norah;Raison;nraison1@wired.com;Female;32;10.05.2000
+Norah;Raison;nraison1@wired.com;Female;32.5;10.05.2000

--- a/test/resource/input_tilde_delimiter.csv
+++ b/test/resource/input_tilde_delimiter.csv
@@ -1,3 +1,3 @@
 firstName~lastName~email~gender~age~birth
 Constantin~Langsdon~clangsdon0@hc360.com~Male~96~10.02.1965
-Norah~Raison~nraison1@wired.com~Female~32~10.05.2000
+Norah~Raison~nraison1@wired.com~Female~32.5~10.05.2000

--- a/test/stringUtils.spec.js
+++ b/test/stringUtils.spec.js
@@ -20,7 +20,7 @@ describe('StringUtils class testing', function () {
     });
 
     describe('getValueFormatByType()', function () {
-        it('should return type of Number', function () {
+        it('should return type of Number for integers', function () {
             //given
             let value = '23';
 
@@ -30,6 +30,18 @@ describe('StringUtils class testing', function () {
             //then
             expect(result).to.be.an('number');
             expect(result).to.equal(23);
+        });
+
+        it('should return type of Number for non-integers', function () {
+            //given
+            let value = '0.23';
+
+            //when
+            let result = stringUtils.getValueFormatByType(value);
+
+            //then
+            expect(result).to.be.an('number');
+            expect(result).to.equal(0.23);
         });
 
         it('should return type of String when value contains only words', function () {


### PR DESCRIPTION
# Context
Currently, the `getValueFormatByType` function does not detect non-integer numbers as numbers.

## Expected
`getValueFormatByType('10.0') // returns 10.0 (number)` 

## Actual
`getValueFormatByType('10.0') // returns '10.0' (string)` 