### PR TITLE
Add a method to allow package usability when the csv is already in st…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-'use strict';
+"use strict";
 
-let csvToJson = require('./src/csvToJson.js');
+let csvToJson = require("./src/csvToJson.js");
 
 /**
  * Prints a digit as Number type (for example 32 instead of '32')
  */
-exports.formatValueByType = function () {
+exports.formatValueByType = function() {
   csvToJson.formatValueByType();
   return this;
 };
@@ -13,7 +13,7 @@ exports.formatValueByType = function () {
 /**
  * Defines the field delimiter which will be used to split the fields
  */
-exports.fieldDelimiter = function (delimiter) {
+exports.fieldDelimiter = function(delimiter) {
   csvToJson.fieldDelimiter(delimiter);
   return this;
 };
@@ -24,14 +24,14 @@ exports.fieldDelimiter = function (delimiter) {
  * @param {outputFileName} path/filename
  *
  */
-exports.generateJsonFileFromCsv = function (inputFileName, outputFileName) {
-    if(!inputFileName){
-        throw new Error('inputFileName is not defined!!!');
-    }
-    if(!outputFileName){
-        throw new Error('outputFileName is not defined!!!');
-    }
-    csvToJson.generateJsonFileFromCsv(inputFileName, outputFileName);
+exports.generateJsonFileFromCsv = function(inputFileName, outputFileName) {
+  if (!inputFileName) {
+    throw new Error("inputFileName is not defined!!!");
+  }
+  if (!outputFileName) {
+    throw new Error("outputFileName is not defined!!!");
+  }
+  csvToJson.generateJsonFileFromCsv(inputFileName, outputFileName);
 };
 
 /**
@@ -40,11 +40,15 @@ exports.generateJsonFileFromCsv = function (inputFileName, outputFileName) {
  * @return {Array} Array of Object in json format
  *
  */
-exports.getJsonFromCsv = function (inputFileName) {
-    if(!inputFileName){
-        throw new Error('inputFileName is not defined!!!');
-    }
-    return csvToJson.getJsonFromCsv(inputFileName);
+exports.getJsonFromCsv = function(inputFileName) {
+  if (!inputFileName) {
+    throw new Error("inputFileName is not defined!!!");
+  }
+  return csvToJson.getJsonFromCsv(inputFileName);
+};
+
+exports.csvStringToJson = function(csvString) {
+  return csvStringToJson(csvString);
 };
 
 /**
@@ -54,6 +58,6 @@ exports.getJsonFromCsv = function (inputFileName) {
  *
  * @deprecated Use generateJsonFileFromCsv()
  */
-exports.jsonToCsv = function (inputFileName, outputFileName) {
-    csvToJson.generateJsonFileFromCsv(inputFileName, outputFileName);
+exports.jsonToCsv = function(inputFileName, outputFileName) {
+  csvToJson.generateJsonFileFromCsv(inputFileName, outputFileName);
 };

--- a/src/csvToJson.js
+++ b/src/csvToJson.js
@@ -1,76 +1,79 @@
-'use strict';
+"use strict";
 
-let fileUtils = require('././util/fileUtils');
-let stringUtils = require('././util/stringUtils');
-let jsonUtils = require('././util/jsonUtils');
+let fileUtils = require("././util/fileUtils");
+let stringUtils = require("././util/stringUtils");
+let jsonUtils = require("././util/jsonUtils");
 
 const newLine = /\r?\n/;
-const defaultFieldDelimiter = ';';
+const defaultFieldDelimiter = ";";
 
 class CsvToJson {
+  formatValueByType() {
+    this.printValueFormatByType = true;
+    return this;
+  }
 
-    formatValueByType() {
-        this.printValueFormatByType = true;
-        return this;
+  fieldDelimiter(delimieter) {
+    this.delimiter = delimieter;
+    return this;
+  }
+
+  generateJsonFileFromCsv(fileInputName, fileOutputName) {
+    let jsonStringified = this.getJsonFromCsvStringified(fileInputName);
+    fileUtils.writeFile(jsonStringified, fileOutputName);
+  }
+
+  getJsonFromCsvStringified(fileInputName) {
+    let json = this.getJsonFromCsv(fileInputName);
+    let jsonStringified = JSON.stringify(json, undefined, 1);
+    jsonUtils.validateJson(jsonStringified);
+    return jsonStringified;
+  }
+
+  getJsonFromCsv(fileInputName) {
+    let parsedCsv = fileUtils.readFile(fileInputName);
+    return this.csvToJson(parsedCsv);
+  }
+
+  csvStringToJson(csvString) {
+    return this.csvToJson(csvString);
+  }
+
+  csvToJson(parsedCsv) {
+    let lines = parsedCsv.split(newLine);
+    let fieldDelimiter = this.getFieldDelimiter();
+    let headers = lines[0].split(fieldDelimiter);
+
+    let jsonResult = [];
+    for (let i = 1; i < lines.length; i++) {
+      let currentLine = lines[i].split(fieldDelimiter);
+      if (stringUtils.hasContent(currentLine)) {
+        jsonResult.push(this.buildJsonResult(headers, currentLine));
+      }
     }
+    return jsonResult;
+  }
 
-    fieldDelimiter(delimieter){
-        this.delimiter = delimieter;
-        return this;
+  getFieldDelimiter() {
+    if (this.delimiter) {
+      return this.delimiter;
     }
+    return defaultFieldDelimiter;
+  }
 
-    generateJsonFileFromCsv(fileInputName, fileOutputName) {
-        let jsonStringified = this.getJsonFromCsvStringified(fileInputName);
-        fileUtils.writeFile(jsonStringified, fileOutputName);
+  buildJsonResult(headers, currentLine) {
+    let jsonObject = {};
+    for (let j = 0; j < headers.length; j++) {
+      let propertyName = stringUtils.trimPropertyName(headers[j]);
+
+      let value = currentLine[j];
+      if (this.printValueFormatByType) {
+        value = stringUtils.getValueFormatByType(currentLine[j]);
+      }
+      jsonObject[propertyName] = value;
     }
-
-    getJsonFromCsvStringified(fileInputName) {
-        let json = this.getJsonFromCsv(fileInputName);
-        let jsonStringified = JSON.stringify(json, undefined, 1);
-        jsonUtils.validateJson(jsonStringified);
-        return jsonStringified;
-    }
-
-    getJsonFromCsv(fileInputName) {
-        let parsedCsv = fileUtils.readFile(fileInputName);
-        return this.csvToJson(parsedCsv);
-    }
-
-    csvToJson(parsedCsv) {
-        let lines = parsedCsv.split(newLine);
-        let fieldDelimiter = this.getFieldDelimiter();
-        let headers = lines[0].split(fieldDelimiter);
-
-        let jsonResult = [];
-        for (let i = 1; i < lines.length; i++) {
-            let currentLine = lines[i].split(fieldDelimiter);
-            if (stringUtils.hasContent(currentLine)) {
-                jsonResult.push(this.buildJsonResult(headers, currentLine));
-            }
-        }
-        return jsonResult;
-    }
-
-    getFieldDelimiter(){
-        if(this.delimiter){
-            return this.delimiter;
-        }
-        return defaultFieldDelimiter;
-    }
-
-    buildJsonResult(headers, currentLine) {
-        let jsonObject = {};
-        for (let j = 0; j < headers.length; j++) {
-            let propertyName = stringUtils.trimPropertyName(headers[j]);
-
-            let value = currentLine[j];
-            if (this.printValueFormatByType) {
-                value = stringUtils.getValueFormatByType(currentLine[j]);
-            }
-            jsonObject[propertyName] = value;
-        }
-        return jsonObject;
-    }
+    return jsonObject;
+  }
 }
 
 module.exports = new CsvToJson();


### PR DESCRIPTION
fileUtils.readFile handles the conversion of a file to a string and I couldn't find an exported method that took the input of a string of csv data a user may already have in memory.

I assume that the csvToJson method is not exported intentionally, so I created a method that calls it and returns the JSON.

