### PR TITLE
trimPropertyName() to trim around only

### DIFF
--- a/src/util/stringUtils.js
+++ b/src/util/stringUtils.js
@@ -3,7 +3,7 @@
 class StringUtils {
 
     trimPropertyName(value) {
-        return value.replace(/\s/g, '');
+        return value.trim();
     }
 
     getValueFormatByType(value) {


### PR DESCRIPTION
- Fixes #67 
- Fixes #29

## Proposed Changes

Use `value.trim()` instead of `value.replace(/\s/g, '')`
```js
const value = " First Header ";
value.replace(/\s/g, ''); // "FirstHeader" ❌ Does not respect the space in the middle.
value.trim(); // "First Header" ✅ Use the built-in trim() method to trim around.
```