### PR TITLE
chore: add node 24 and remove node 21 to/from ci -cd workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 22.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x, 21.x, 22.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 22.x, 22.x]
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
CI CD workflow is not testing node 24, and node 21 is not supported anymore anyway...