### PR TITLE
Feature: Column filtering with ignoreColumnIndexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ All APIs (Sync, Async and Browser) support the same configuration methods:
 - `supportQuotedField(bool)` - Handle quoted fields with embedded delimiters
 - `indexHeader(num)` - Specify header row (default: 0)
 - `trimHeaderFieldWhiteSpace(bool)` - Remove spaces from headers
+- `ignoreColumnIndexes(indexes)` - Exclude specific columns by index from the JSON output
 - `parseSubArray(delim, sep)` - Parse delimited arrays
 - `mapRows(fn)` - Transform, filter, or enrich each row
 - `getJsonFromStreamAsync(stream)` - Process CSV from Readable streams for NodeJS and Browser

--- a/docs/BROWSER.md
+++ b/docs/BROWSER.md
@@ -227,6 +227,22 @@ const json = convert.browser
 // Output: { Name: 'Alice', Age: '30' } (spaces removed from header)
 ```
 
+### Ignore Column Indexes
+
+```js
+const csv = 'name,age,active\nAlice,30,true\nBob,25,false';
+
+const json = convert.browser
+  .ignoreColumnIndexes([2])
+  .csvStringToJson(csv);
+
+// Output:
+// [
+//   { name: 'Alice', age: 30 },
+//   { name: 'Bob', age: 25 }
+// ]
+```
+
 ### Method Chaining
 
 ```js

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -198,6 +198,31 @@ const json = csvToJson.csvStringToJson(csv);
 const jsonString = csvToJson.csvStringToJsonStringified(csv);
 ```
 
+### Ignore Column Indexes
+Exclude specific columns from the JSON output by specifying their column indexes:
+
+```js
+// Ignore columns at index 2 and 3
+csvToJson
+  .ignoreColumnIndexes([2, 3])
+  .getJsonFromCsv('file.csv');
+```
+
+**Example Input:**
+```csv
+name,email,active,id
+John,john@example.com,true,0012
+Jane,jane@example.com,false,987
+```
+
+**Output:**
+```json
+[
+  { "name": "John", "email": "John,john@example.com" },
+  { "name": "Jane", "email": "jane@example.com" }
+]
+```
+
 ### Method Chaining
 
 Combine multiple configuration options:

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,12 @@ declare module 'convert-csv-to-json' {
     parseSubArray(delimiter: string, separator: string): this;
 
     /**
+     * Set column indexes to ignore
+     * Specified columns will be excluded from the JSON output
+     */
+    ignoreColumnIndexes(indexes: number[]): this;
+
+    /**
      * Defines a custom encoding to decode a file
      */
     customEncoding(encoding: string): this;
@@ -139,6 +145,7 @@ declare module 'convert-csv-to-json' {
     fieldDelimiter(delimiter: string): this;
     indexHeader(index: number): this;
     parseSubArray(delimiter: string, separator: string): this;
+    ignoreColumnIndexes(indexes: number[]): this;
     mapRows(mapperFn: (row: any, index: number) => any | null): this;
 
     csvStringToJson(csvString: string): any[];

--- a/index.js
+++ b/index.js
@@ -96,6 +96,26 @@ exports.parseSubArray = function (delimiter, separator) {
 };
 
 /**
+ * Set column indexes to ignore
+ * Specified columns will be excluded from the JSON output
+ * @category 1-Core API
+ * @param {Array<number>} indexes - Array of column indexes to ignore
+ * @returns {object} Module context for method chaining
+ * @example
+ * csvToJson.ignoreColumnIndexes([1, 3]) // Ignore columns at index 1 and 3
+ */
+exports.ignoreColumnIndexes = function (indexes) {
+  if (!Array.isArray(indexes)) {
+    throw new TypeError('indexes must be an array of numbers');
+  }
+  if (!indexes.every(idx => Number.isInteger(idx) && idx >= 0)) {
+    throw new TypeError('All elements in indexes must be valid non-negative numbers (>= 0)');
+  }
+  csvToJson.ignoreColumnIndexes(indexes);
+  return this;
+};
+
+/**
  * Set custom file encoding for reading CSV files
  * Useful for non-UTF8 encoded files
  * @category 1-Core API

--- a/src/browserApi.js
+++ b/src/browserApi.js
@@ -72,6 +72,17 @@ class BrowserApi {
   }
 
   /**
+   * Configure columns to exclude from output
+   * @param {Array<number>} indexes - Column indexes to ignore
+   * @returns {this} For method chaining
+   * @private Used internally after validation in index.js
+   */
+  ignoreColumnIndexes(indexes) {
+    this.csvToJson.ignoreColumnIndexes(indexes);
+    return this;
+  }
+
+  /**
    * Configure sub-array parsing for special field values
    * @param {string} delimiter - Bracket character (default: '*')
    * @param {string} separator - Item separator within brackets (default: ',')

--- a/src/csvToJson.js
+++ b/src/csvToJson.js
@@ -108,6 +108,17 @@ class CsvToJson {
   }
 
   /**
+   * Configure columns to exclude from output
+   * @param {Array<number>} indexes - Column indexes to ignore
+   * @returns {this} For method chaining
+   * @private Used internally after validation in index.js
+   */
+  ignoreColumnIndexes(indexes) {
+    this.indexesToIgnore = new Set(indexes);
+    return this;
+  }
+
+  /**
    * Sets a mapper function to transform each row after conversion
    * @param {function(object, number): (object|null)} mapperFn - Function that receives (row, index) and returns transformed row or null to filter out
    * @returns {this} For method chaining
@@ -375,6 +386,10 @@ class CsvToJson {
   buildJsonResult(headers, currentLine) {
     let jsonObject = {};
     for (let j = 0; j < headers.length; j++) {
+      if (this.indexesToIgnore?.has(j)) {
+        continue;
+      }
+
       let propertyName = stringUtils.trimPropertyName(this.isTrimHeaderFieldWhiteSpace, headers[j]);
       let value = currentLine[j];
 

--- a/src/csvToJsonAsync.js
+++ b/src/csvToJsonAsync.js
@@ -102,6 +102,17 @@ class CsvToJsonAsync {
     }
 
     /**
+     * Configure columns to exclude from output
+     * @param {Array<number>} indexes - Column indexes to ignore
+     * @returns {this} For method chaining
+     * @private Used internally after validation in index.js
+     */
+    ignoreColumnIndexes(indexes) {
+        this.csvToJson.ignoreColumnIndexes(indexes);
+        return this;
+    }
+
+    /**
      * Read a CSV file and write parsed JSON to an output file (async)
      * @param {string} fileInputName - Path to input CSV file
      * @param {string} fileOutputName - Path to output JSON file

--- a/test/ignoreColumnIndexes.spec.js
+++ b/test/ignoreColumnIndexes.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+let index = require('../index');
+
+describe('Ignore Column Indexes testing', function () {
+    it('should ignore column at index 0', function () {
+        //when
+        let result = index
+            .ignoreColumnIndexes([0])
+            .getJsonFromCsv('test/resource/input_header_row0.csv');
+
+        //then
+        expect(result).toEqual([
+            {
+                age: '30',
+                city: 'NewYork'
+            },
+            {
+                age: '25',
+                city: 'Boston'
+            }
+        ]);
+    });
+
+    it('should ignore columns at indexes 0 and 2', function () {
+        //when
+        let result = index
+            .ignoreColumnIndexes([0, 2])
+            .getJsonFromCsv('test/resource/input_header_row0.csv');
+
+        //then
+        expect(result).toEqual([
+            {
+                age: '30'
+            },
+            {
+                age: '25'
+            }
+        ]);
+    });
+
+    it('should throw TypeError when indexes is not an array', function () {
+        expect(() => index.ignoreColumnIndexes('not an array')).toThrow(
+            new TypeError('indexes must be an array of numbers')
+        );
+    });
+
+    it('should throw TypeError when indexes is null', function () {
+        expect(() => index.ignoreColumnIndexes(null)).toThrow(
+            new TypeError('indexes must be an array of numbers')
+        );
+    });
+
+    it('should throw TypeError when indexes is an object', function () {
+        expect(() => index.ignoreColumnIndexes({ 0: 1, 1: 2 })).toThrow(
+            new TypeError('indexes must be an array of numbers')
+        );
+    });
+
+    it('should throw TypeError when array contains non-numeric values', function () {
+        expect(() => index.ignoreColumnIndexes([0, 'string', 2])).toThrow(
+            new TypeError('All elements in indexes must be valid non-negative numbers (>= 0)')
+        );
+    });
+
+    it('should throw TypeError when array contains NaN', function () {
+        expect(() => index.ignoreColumnIndexes([0, NaN, 2])).toThrow(
+            new TypeError('All elements in indexes must be valid non-negative numbers (>= 0)')
+        );
+    });
+
+    it('should throw TypeError when array contains negative numbers', function () {
+        expect(() => index.ignoreColumnIndexes([0, -1, 2])).toThrow(
+            new TypeError('All elements in indexes must be valid non-negative numbers (>= 0)')
+        );
+    });
+
+    it('should throw TypeError when array contains floating point numbers', function () {
+        expect(() => index.ignoreColumnIndexes([0, 1.5, 2])).toThrow(
+            new TypeError('All elements in indexes must be valid non-negative numbers (>= 0)')
+        );
+    });
+
+    it('should accept empty array', function () {
+        let result = index
+            .ignoreColumnIndexes([])
+            .getJsonFromCsv('test/resource/input_header_row0.csv');
+
+        expect(result.length).toBeGreaterThan(0);
+    });
+
+});


### PR DESCRIPTION
Fixes #123

## New Features

### Ignore Column Indexes
Exclude specific columns from the JSON output by specifying their column indexes:

```js
// Ignore columns at index 2 and 3
csvToJson
  .ignoreColumnIndexes([2, 3])
  .getJsonFromCsv('file.csv');
```

**Example Input:**
```csv
name,email,active,id
John,john@example.com,true,0012
Jane,jane@example.com,false,987
```

**Output:**
```json
[
  { "name": "John", "email": "john@example.com" },
  { "name": "Jane", "email": "jane@example.com" }
]
```
